### PR TITLE
Fixing bugs related to cpu/gpu device mismatch

### DIFF
--- a/src/prep/build_semantic_index.py
+++ b/src/prep/build_semantic_index.py
@@ -117,10 +117,10 @@ def build_embedding_array(vault: dict, tokenizer, model, batch_size=4) -> np.nda
 
 
 def query_semantic(query, tokenizer, model, doc_embeddings_array, n_results=10):
-    query_tokenized = tokenizer(f'query: {query}', max_length=512, padding=False, truncation=True, return_tensors='pt')
+    query_tokenized = tokenizer(f'query: {query}', max_length=512, padding=False, truncation=True, return_tensors='pt').to(DEVICE)
     outputs = model(**query_tokenized)
     query_embedding = average_pool(outputs.last_hidden_state, query_tokenized['attention_mask'])
-    query_embedding = F.normalize(query_embedding, p=2, dim=1).detach().numpy()
+    query_embedding = F.normalize(query_embedding, p=2, dim=1).detach().cpu().numpy()
 
     cos_sims = np.dot(doc_embeddings_array, query_embedding.T)
     cos_sims = cos_sims.flatten()


### PR DESCRIPTION
This PR fixes CPU/GPU device mixups while running in the `query_semantic` function.

- The tokenized query needs to be on the same device as the model 
- While converting the embedding to numpy, we need first copy the array on CPU before calling `.numpy()` function.