### PR TITLE
Add double quotes on make-install for $OBSIDIAN_PATH containing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 
 install-plugin:
 	mkdir -p ${OBSIDIAN_PATH}.obsidian/plugins/copilot/
-	cp plugin/main.ts plugin/main.js plugin/styles.css plugin/manifest.json ${OBSIDIAN_PATH}.obsidian/plugins/copilot/
+	cp plugin/main.ts plugin/main.js plugin/styles.css plugin/manifest.json "${OBSIDIAN_PATH}.obsidian/plugins/copilot/"
 
 # Development
 dev: build


### PR DESCRIPTION
Got an error when copying files to an obsidian vault containing a space e.g. "Obsidian Vault"

<img width="888" alt="Screenshot 2024-05-16 at 1 02 15 AM" src="https://github.com/eugeneyan/obsidian-copilot/assets/12984659/87893f1f-53b8-4b1c-8d27-4f2c94dd7a92">
